### PR TITLE
Add --[no-]force-autogen option (default: off)

### DIFF
--- a/.github/workflows/centos-7-head.yml
+++ b/.github/workflows/centos-7-head.yml
@@ -51,5 +51,4 @@ jobs:
           # set path etc
           . /opt/ribose/ribose-automake116/enable
 
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/centos-7-latest.yml
+++ b/.github/workflows/centos-7-latest.yml
@@ -51,5 +51,4 @@ jobs:
           # set path etc
           . /opt/ribose/ribose-automake116/enable
 
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/centos-7.yml
+++ b/.github/workflows/centos-7.yml
@@ -79,5 +79,4 @@ jobs:
           # set path etc
           . /opt/ribose/ribose-automake116/enable
 
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/centos-8-head.yml
+++ b/.github/workflows/centos-8-head.yml
@@ -40,5 +40,4 @@ jobs:
             file
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/centos-8-latest.yml
+++ b/.github/workflows/centos-8-latest.yml
@@ -40,5 +40,4 @@ jobs:
             file
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/centos-8.yml
+++ b/.github/workflows/centos-8.yml
@@ -63,5 +63,4 @@ jobs:
           bash ci/import_gpg_keys.sh
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/fedora-33-head.yml
+++ b/.github/workflows/fedora-33-head.yml
@@ -40,5 +40,4 @@ jobs:
             file
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/fedora-33-latest.yml
+++ b/.github/workflows/fedora-33-latest.yml
@@ -40,5 +40,4 @@ jobs:
             file
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/fedora-33.yml
+++ b/.github/workflows/fedora-33.yml
@@ -68,5 +68,4 @@ jobs:
           bash ci/import_gpg_keys.sh
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-14.04-head.yml
+++ b/.github/workflows/ubuntu-14.04-head.yml
@@ -37,5 +37,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-14.04-latest.yml
+++ b/.github/workflows/ubuntu-14.04-latest.yml
@@ -37,5 +37,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-14.04.yml
+++ b/.github/workflows/ubuntu-14.04.yml
@@ -64,5 +64,4 @@ jobs:
           bash ci/import_gpg_keys.sh
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-16.04-head.yml
+++ b/.github/workflows/ubuntu-16.04-head.yml
@@ -37,5 +37,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-16.04-latest.yml
+++ b/.github/workflows/ubuntu-16.04-latest.yml
@@ -37,5 +37,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-16.04.yml
+++ b/.github/workflows/ubuntu-16.04.yml
@@ -59,5 +59,4 @@ jobs:
           bash ci/import_gpg_keys.sh
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-18.04-head.yml
+++ b/.github/workflows/ubuntu-18.04-head.yml
@@ -37,5 +37,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-18.04-latest.yml
+++ b/.github/workflows/ubuntu-18.04-latest.yml
@@ -37,5 +37,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-18.04.yml
+++ b/.github/workflows/ubuntu-18.04.yml
@@ -59,5 +59,4 @@ jobs:
           bash ci/import_gpg_keys.sh
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-20.04-head.yml
+++ b/.github/workflows/ubuntu-20.04-head.yml
@@ -41,5 +41,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-20.04-latest.yml
+++ b/.github/workflows/ubuntu-20.04-latest.yml
@@ -41,5 +41,4 @@ jobs:
             libgnutls28-dev bzip2 make gettext texinfo gnutls-bin build-essential g++
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/.github/workflows/ubuntu-20.04.yml
+++ b/.github/workflows/ubuntu-20.04.yml
@@ -68,5 +68,4 @@ jobs:
           bash ci/import_gpg_keys.sh
       - name: Build GPG
         run: |
-          set -x
-          "./examples/${SCRIPT}.sh"
+          bash -x "./examples/${SCRIPT}.sh"

--- a/examples/all_2.1.sh
+++ b/examples/all_2.1.sh
@@ -18,7 +18,7 @@ set -v # Print executed lines
 # reconfigure dynamic linker run-time bindings, in other words to make the
 # installed shared libraries working correctly.  This option should not be
 # enabled on systems which do not feature `ldconfig`.
-./install_gpg_all.sh --suite-version 2.1 --sudo --ldconfig
+./install_gpg_all.sh --suite-version 2.1 --sudo --ldconfig "$@"
 
 ###############
 #    TESTS    #

--- a/examples/all_2.2.sh
+++ b/examples/all_2.2.sh
@@ -18,7 +18,7 @@ set -v # Print executed lines
 # reconfigure dynamic linker run-time bindings, in other words to make the
 # installed shared libraries working correctly.  This option should not be
 # enabled on systems which do not feature `ldconfig`.
-./install_gpg_all.sh --suite-version 2.2 --sudo --ldconfig
+./install_gpg_all.sh --suite-version 2.2 --sudo --ldconfig "$@"
 
 ###############
 #    TESTS    #

--- a/examples/all_head.sh
+++ b/examples/all_head.sh
@@ -36,7 +36,7 @@ fi
 # by default, build fails for some reason.  Fixing it for unstable Pinentry
 # version is out of the scope of this example.
 ./install_gpg_all.sh --suite-version master --sudo --ldconfig \
-	--configure-opts "--disable-doc --disable-pinentry-qt"
+	--configure-opts "--disable-doc --disable-pinentry-qt" "$@"
 
 ###############
 #    TESTS    #

--- a/examples/all_latest.sh
+++ b/examples/all_latest.sh
@@ -19,7 +19,7 @@ set -v # Print executed lines
 # reconfigure dynamic linker run-time bindings, in other words to make the
 # installed shared libraries working correctly.  This option should not be
 # enabled on systems which do not feature `ldconfig`.
-./install_gpg_all.sh --suite-version latest --sudo --ldconfig
+./install_gpg_all.sh --suite-version latest --sudo --ldconfig "$@"
 
 ###############
 #    TESTS    #

--- a/examples/build_dir.sh
+++ b/examples/build_dir.sh
@@ -14,7 +14,7 @@ set -v # Print executed lines
 #    SETUP    #
 ###############
 
-BUILD_DIR="${TRAVIS_BUILD_DIR}/b"
+BUILD_DIR="${TRAVIS_BUILD_DIR:-$(mktemp -d)}/b"
 
 mkdir -p ${BUILD_DIR}
 

--- a/examples/build_dir.sh
+++ b/examples/build_dir.sh
@@ -28,7 +28,7 @@ mkdir -p ${BUILD_DIR}
 # installed shared libraries working correctly.  This option should not be
 # enabled on systems which do not feature `ldconfig`.
 ./install_gpg_all.sh --suite-version 2.2 --sudo --ldconfig \
-	--build-dir ${BUILD_DIR}
+	--build-dir "${BUILD_DIR}" "$@"
 
 ###############
 #    TESTS    #

--- a/examples/build_dir.sh
+++ b/examples/build_dir.sh
@@ -16,7 +16,7 @@ set -v # Print executed lines
 
 BUILD_DIR="${TRAVIS_BUILD_DIR:-$(mktemp -d)}/b"
 
-mkdir -p ${BUILD_DIR}
+mkdir -p "${BUILD_DIR}"
 
 # The --sudo option is typically needed when installing to standard locations.
 # Note that `sudo ./install_gpg_all …` is not the same—it would compile as
@@ -45,9 +45,9 @@ gpg --version | head -n 1 | cut -d" " -f 3 | grep -xE "2\.2\.[0-9]+"
 
 # Assert that ${BUILD_DIR} is now full of files (cause build had happened
 # there)…
-pushd ${BUILD_DIR}
+pushd "${BUILD_DIR}"
 ls -d libgpg-error-*
 ls -d gnupg-*
-[[ -f "$(ls | grep "libgpg-error-")/Makefile" ]]
-[[ -f "$(ls | grep "gnupg-")/Makefile" ]]
+ls libgpg-error-*/Makefile
+ls gnupg-*/Makefile
 popd

--- a/examples/components_individually.sh
+++ b/examples/components_individually.sh
@@ -28,40 +28,40 @@ BUILD_DIR="${TRAVIS_BUILD_DIR:-$(mktemp -d)}/b"
 	--configure-opts "--disable-doc" \
 	--verbose \
 	--sudo \
-	--ldconfig
+	--ldconfig "$@"
 ./install_gpg_component.sh \
 	--component-name libgcrypt \
 	--component-version latest \
 	--build-dir "${BUILD_DIR}" \
 	--sudo \
-	--ldconfig
+	--ldconfig "$@"
 ./install_gpg_component.sh \
 	--component-name libassuan \
 	--component-version latest \
 	--sudo \
-	--ldconfig
+	--ldconfig "$@"
 ./install_gpg_component.sh \
 	--component-name libksba \
 	--component-version latest \
 	--sudo \
-	--ldconfig
+	--ldconfig "$@"
 ./install_gpg_component.sh \
 	--component-name npth \
 	--component-version latest \
 	--sudo \
-	--ldconfig
+	--ldconfig "$@"
 ./install_gpg_component.sh \
 	--component-name pinentry \
 	--component-version 1.1.0 \
 	--sudo \
-	--ldconfig
+	--ldconfig "$@"
 ./install_gpg_component.sh \
 	--component-name gnupg \
 	--component-version 2.2.20 \
 	--configure-opts "--enable-gpg-sha256 --disable-gpg-sha512 --enable-doc" \
 	--verbose \
 	--sudo \
-	--ldconfig
+	--ldconfig "$@"
 
 ###############
 #    TESTS    #

--- a/examples/components_individually.sh
+++ b/examples/components_individually.sh
@@ -16,7 +16,7 @@ set -v # Print executed lines
 #    SETUP    #
 ###############
 
-BUILD_DIR="${TRAVIS_BUILD_DIR}/b"
+BUILD_DIR="${TRAVIS_BUILD_DIR:-$(mktemp -d)}/b"
 
 # Install specific versions of some components.  Disable documentation for
 # libgpg-error, and enable it (default) for other components.

--- a/examples/components_individually.sh
+++ b/examples/components_individually.sh
@@ -77,8 +77,8 @@ gpg --version
 gpg --version | head -n 1 | cut -d" " -f 3 | grep -xF "2.2.20"
 
 # Assert configured algorithms (enabled SHA256 and disabled SHA512)…
-gpg --version | grep -i "SHA256"
-[[ ! $(gpg --version | grep -i "SHA512") ]]
+gpg --version | grep -q -i "SHA256"
+gpg --version | grep -q -v -i "SHA512"
 
 # Assert disabled docs for libgpg-error, and enabled for other packages…
 [[   -f "/usr/local/share/man/man1/gpg.1" ]]
@@ -86,8 +86,8 @@ gpg --version | grep -i "SHA256"
 
 # Assert that building the libgcrypt component has happened in a $BUILD_DIR,
 # and no other component was built there…
-pushd ${BUILD_DIR}
+pushd "${BUILD_DIR}"
 ls -d libgcrypt-*
-[[ ! $(ls . | grep -v "libgcrypt-") ]]
-[[ -f "$(ls | grep "libgcrypt-")/Makefile" ]]
+ls libgcrypt-*
+ls libgcrypt-*/Makefile
 popd

--- a/examples/configure_options.sh
+++ b/examples/configure_options.sh
@@ -37,5 +37,5 @@ gpg --version | head -n 1 | cut -d" " -f 3 | grep -xE "2\.2\.[0-9]+"
 [[ ! -f "/usr/local/share/man/man7/gnupg.7" ]]
 
 # Assert configured algorithms (enabled SHA256 and disabled SHA512)…
-gpg --version | grep -i "SHA256"
+gpg --version | grep -q -i "SHA256"
 gpg --version | grep -q -v -i "SHA512"

--- a/examples/configure_options.sh
+++ b/examples/configure_options.sh
@@ -16,7 +16,7 @@ set -v # Print executed lines
 # warnings will be printed.
 ./install_gpg_all.sh --suite-version latest --sudo --ldconfig \
 	--configure-opts "--disable-doc --enable-pinentry-curses \
-	--enable-gpg-sha256 --disable-gpg-sha512"
+	--enable-gpg-sha256 --disable-gpg-sha512" "$@"
 
 ###############
 #    TESTS    #

--- a/examples/gpgme.sh
+++ b/examples/gpgme.sh
@@ -13,9 +13,9 @@ set -v # Print executed lines
 # Note that `sudo ./install_gpg_all …` is not the same—it would compile as
 # root (not recommended).
 ./install_gpg_all.sh \
-	--suite-version latest --sudo --ldconfig
+	--suite-version latest --sudo --ldconfig "$@"
 ./install_gpg_component.sh \
-	--component-name gpgme --component-version latest --sudo --ldconfig
+	--component-name gpgme --component-version latest --sudo --ldconfig "$@"
 
 ###############
 #    TESTS    #

--- a/examples/install_prefix.sh
+++ b/examples/install_prefix.sh
@@ -30,7 +30,7 @@ GPG_CONFIGURE_OPTS="--prefix=${GPG_PREFIX} \
 # provided with $PATH and $GPG_PREFIX, hence we must enhance $PATH.
 export PATH="${EXEC_PREFIX}/bin:${PATH}"
 
-mkdir -p ${GPG_PREFIX} ${EXEC_PREFIX} ${MAN_DIR}
+mkdir -p "${GPG_PREFIX}" "${EXEC_PREFIX}" "${MAN_DIR}"
 
 # The --ldconfig option is typically needed on GNU+Linux systems.  It causes
 # `ldconfig` to be run right after installing each component in order to

--- a/examples/install_prefix.sh
+++ b/examples/install_prefix.sh
@@ -40,7 +40,7 @@ mkdir -p ${GPG_PREFIX} ${EXEC_PREFIX} ${MAN_DIR}
 # custom prefixes, a correct path to shared libraries will be obtained from
 # the `./configure` script.
 ./install_gpg_all.sh --suite-version latest --sudo --ldconfig \
-	--configure-opts "${GPG_CONFIGURE_OPTS}"
+	--configure-opts "${GPG_CONFIGURE_OPTS}" "$@"
 
 ###############
 #    TESTS    #

--- a/examples/install_prefix.sh
+++ b/examples/install_prefix.sh
@@ -10,9 +10,10 @@ set -v # Print executed lines
 # This example shows how to install GnuPG to a non-standard location
 # (overriding both --prefix, and --exec-prefix )
 
-GPG_PREFIX="${TRAVIS_BUILD_DIR}/opt/gpg-all/universal"
-EXEC_PREFIX="${TRAVIS_BUILD_DIR}/opt/gpg-all/arch"
-MAN_DIR="${TRAVIS_BUILD_DIR}/opt/gpg-all/manual"
+BUILD_DIR="${TRAVIS_BUILD_DIR:-$(mktemp -d)}"
+GPG_PREFIX="${BUILD_DIR}/opt/gpg-all/universal"
+EXEC_PREFIX="${BUILD_DIR}/opt/gpg-all/arch"
+MAN_DIR="${BUILD_DIR}/opt/gpg-all/manual"
 
 GPG_CONFIGURE_OPTS="--prefix=${GPG_PREFIX} \
 	--exec-prefix=${EXEC_PREFIX} \

--- a/examples/no_ldconfig.sh
+++ b/examples/no_ldconfig.sh
@@ -53,7 +53,7 @@ mkdir -p "${PREFIX}"
 # The --sudo option is typically needed when installing to standard locations.
 # Note that `sudo ./install_gpg_all …` is not the same—it would compile as
 # root (not recommended).
-./install_gpg_all.sh --suite-version latest --sudo --configure-opts "${GPG_CONFIGURE_OPTS}"
+./install_gpg_all.sh --suite-version latest --sudo --configure-opts "${GPG_CONFIGURE_OPTS}" "$@"
 
 ###############
 #    TESTS    #

--- a/examples/no_sudo.sh
+++ b/examples/no_sudo.sh
@@ -10,7 +10,7 @@ set -v # Print executed lines
 # This example shows how to install GnuPG to a non-standard location
 # (overriding both --prefix, and --exec-prefix )
 
-GPG_PREFIX="${TRAVIS_BUILD_DIR}/opt/gpg-all"
+GPG_PREFIX="${TRAVIS_BUILD_DIR:-$(mktemp -d)}/opt/gpg-all"
 
 GPG_CONFIGURE_OPTS="--prefix=${GPG_PREFIX} \
 	--with-libgpg-error-prefix=${GPG_PREFIX} \

--- a/examples/no_sudo.sh
+++ b/examples/no_sudo.sh
@@ -30,7 +30,7 @@ export PATH="${GPG_PREFIX}/bin:${PATH}"
 mkdir -p ${GPG_PREFIX}
 
 ./install_gpg_all.sh --suite-version latest --no-sudo \
-	--configure-opts "${GPG_CONFIGURE_OPTS}"
+	--configure-opts "${GPG_CONFIGURE_OPTS}" "$@"
 
 ###############
 #    TESTS    #

--- a/examples/no_sudo.sh
+++ b/examples/no_sudo.sh
@@ -27,7 +27,7 @@ export LD_RUN_PATH="${GPG_PREFIX}/lib:${LD_RUN_PATH}"
 # provided with $PATH and $GPG_PREFIX, hence we must enhance $PATH.
 export PATH="${GPG_PREFIX}/bin:${PATH}"
 
-mkdir -p ${GPG_PREFIX}
+mkdir -p "${GPG_PREFIX}"
 
 ./install_gpg_all.sh --suite-version latest --no-sudo \
 	--configure-opts "${GPG_CONFIGURE_OPTS}" "$@"

--- a/examples/verify.sh
+++ b/examples/verify.sh
@@ -24,7 +24,7 @@ set -v # Print executed lines
 # reconfigure dynamic linker run-time bindings, in other words to make the
 # installed shared libraries working correctly.  This option should not be
 # enabled on systems which do not feature `ldconfig`.
-./install_gpg_all.sh --suite-version 2.2 --sudo --ldconfig --verify 2>&1 | \
+./install_gpg_all.sh --suite-version 2.2 --sudo --ldconfig --verify "$@" 2>&1 | \
 	tee ./output
 
 ###############

--- a/install_gpg_component.sh
+++ b/install_gpg_component.sh
@@ -85,6 +85,11 @@ OPTIONS
 
 		By default this option is off.
 
+	--[no-]force-autogen
+		Whether to do './autogen.sh', regardless of whether 'configure' exists.
+
+		By default this option is off.
+
 	--[no-]sudo
 		Whether to do 'sudo make install', or just 'make install', and whether
 		to update ldconfig configuration. Note that the ldconfig update is
@@ -133,6 +138,7 @@ set_default_options()
 	_arg_sudo="off"
 	_arg_verify="off"
 	_arg_verbose=()
+	_arg_force_autogen="off"
 	_arg_git="off"
 	_arg_color="off"
 	_arg_folding_style="none"
@@ -168,6 +174,14 @@ parse_cli_arguments()
 			--configure-opts)
 				_arg_configure_opts="$2"
 				shift
+				shift
+				;;
+			--force-autogen)
+				_arg_force_autogen="on"
+				shift
+				;;
+			--no-force-autogen)
+				_arg_force_autogen="off"
 				shift
 				;;
 			--ldconfig)
@@ -390,7 +404,7 @@ build_and_install()
 
 	patch_sources
 
-	if [[ ! -f configure ]]; then
+	if [[ ! -f configure ]] || [[ "${_arg_force_autogen}" = "on" ]]; then
 		fold_start "component.${_arg_component}.autogen"
 		./autogen.sh
 		fold_end "component.${_arg_component}.autogen"


### PR DESCRIPTION
This is to tackle issues of automake version mismatch with aclocal.m4, etc.

Adding `--force-autogen` forces `./autogen.sh` to be run, which should resolve the aforementioned issue.