### PR TITLE
Add workflows for macOS

### DIFF
--- a/.github/workflows/macos-10.15-head.yml
+++ b/.github/workflows/macos-10.15-head.yml
@@ -1,0 +1,52 @@
+name: macOS 10.15 (head)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  tests:
+    runs-on: macos-10.15
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        env:
+          - SCRIPT: all_head
+
+    env: ${{ matrix.env }}
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up build environment
+        run: |
+          cat > Brewfile <<BREWFILE
+          brew "openssl@1.1"
+          brew "make"
+          brew "autoconf"
+          brew "automake"
+          brew "libtool"
+          brew "pkg-config"
+          brew "gnupg"
+          brew "bison"
+          BREWFILE
+
+          brew update-reset
+          # homebrew fails because `openssl` is a symlink while it tries to remove a directory.
+          rm /usr/local/Cellar/openssl || true
+          # homebrew fails to update python 3.9.1 to 3.9.1.1 due to unlinking failure
+          rm /usr/local/bin/2to3 || true
+
+          brew bundle
+      - name: Build GPG
+        # Workaround to correctly build pinentry on the latest GHA on
+        # macOS.  Most likely there is a better solution.
+        env:
+          CFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+          CXXFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+        run: |
+          bash -x "./examples/${SCRIPT}.sh" --no-ldconfig

--- a/.github/workflows/macos-10.15-latest.yml
+++ b/.github/workflows/macos-10.15-latest.yml
@@ -1,0 +1,52 @@
+name: macOS 10.15 (latest)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  tests:
+    runs-on: macos-10.15
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        env:
+          - SCRIPT: all_latest
+
+    env: ${{ matrix.env }}
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up build environment
+        run: |
+          cat > Brewfile <<BREWFILE
+          brew "openssl@1.1"
+          brew "make"
+          brew "autoconf"
+          brew "automake"
+          brew "libtool"
+          brew "pkg-config"
+          brew "gnupg"
+          brew "bison"
+          BREWFILE
+
+          brew update-reset
+          # homebrew fails because `openssl` is a symlink while it tries to remove a directory.
+          rm /usr/local/Cellar/openssl || true
+          # homebrew fails to update python 3.9.1 to 3.9.1.1 due to unlinking failure
+          rm /usr/local/bin/2to3 || true
+
+          brew bundle
+      - name: Build GPG
+        # Workaround to correctly build pinentry on the latest GHA on
+        # macOS.  Most likely there is a better solution.
+        env:
+          CFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+          CXXFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+        run: |
+          bash -x "./examples/${SCRIPT}.sh" --no-ldconfig

--- a/.github/workflows/macos-10.15.yml
+++ b/.github/workflows/macos-10.15.yml
@@ -1,0 +1,72 @@
+name: macOS 10.15
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  tests:
+    runs-on: macos-10.15
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        env:
+          - SCRIPT: all_2.1
+          - SCRIPT: all_2.2
+          - SCRIPT: build_dir
+          - SCRIPT: components_individually
+          - SCRIPT: configure_options
+          - SCRIPT: gpgme
+          - SCRIPT: install_prefix
+          - SCRIPT: no_ldconfig
+          - SCRIPT: no_sudo
+          - SCRIPT: verify
+
+        exclude:
+          - env:
+              SCRIPT: all_2.1  # libksba too old for macOS
+          - env:
+              SCRIPT: no_sudo
+
+    env: ${{ matrix.env }}
+    timeout-minutes: 70
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up build environment
+        run: |
+          cat > Brewfile <<BREWFILE
+          brew "openssl@1.1"
+          brew "make"
+          brew "autoconf"
+          brew "automake"
+          brew "libtool"
+          brew "pkg-config"
+          brew "gnupg"
+          brew "bison"
+          BREWFILE
+
+          brew update-reset
+          # homebrew fails because `openssl` is a symlink while it tries to remove a directory.
+          rm /usr/local/Cellar/openssl || true
+          # homebrew fails to update python 3.9.1 to 3.9.1.1 due to unlinking failure
+          rm /usr/local/bin/2to3 || true
+
+          brew bundle
+      - name: Import GnuPG keys for "verify.sh" example
+        if: ${{ matrix.env.SCRIPT == 'verify' }}
+        run: |
+          bash ci/import_gpg_keys.sh
+      - name: Build GPG
+        # Workaround to correctly build pinentry on the latest GHA on
+        # macOS.  Most likely there is a better solution.
+        env:
+          CFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+          CXXFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+        run: |
+          bash -x "./examples/${SCRIPT}.sh" --no-ldconfig

--- a/.github/workflows/macos-11.0-head.yml
+++ b/.github/workflows/macos-11.0-head.yml
@@ -1,0 +1,52 @@
+name: macOS 11.0 (head)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  tests:
+    runs-on: macos-11.0
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        env:
+          - SCRIPT: all_head
+
+    env: ${{ matrix.env }}
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up build environment
+        run: |
+          cat > Brewfile <<BREWFILE
+          brew "openssl@1.1"
+          brew "make"
+          brew "autoconf"
+          brew "automake"
+          brew "libtool"
+          brew "pkg-config"
+          brew "gnupg"
+          brew "bison"
+          BREWFILE
+
+          brew update-reset
+          # homebrew fails because `openssl` is a symlink while it tries to remove a directory.
+          rm /usr/local/Cellar/openssl || true
+          # homebrew fails to update python 3.9.1 to 3.9.1.1 due to unlinking failure
+          rm /usr/local/bin/2to3 || true
+
+          brew bundle
+      - name: Build GPG
+        # Workaround to correctly build pinentry on the latest GHA on
+        # macOS.  Most likely there is a better solution.
+        env:
+          CFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+          CXXFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+        run: |
+          bash -x "./examples/${SCRIPT}.sh" --no-ldconfig

--- a/.github/workflows/macos-11.0-latest.yml
+++ b/.github/workflows/macos-11.0-latest.yml
@@ -1,0 +1,52 @@
+name: macOS 11.0 (latest)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  tests:
+    runs-on: macos-11.0
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        env:
+          - SCRIPT: all_latest
+
+    env: ${{ matrix.env }}
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up build environment
+        run: |
+          cat > Brewfile <<BREWFILE
+          brew "openssl@1.1"
+          brew "make"
+          brew "autoconf"
+          brew "automake"
+          brew "libtool"
+          brew "pkg-config"
+          brew "gnupg"
+          brew "bison"
+          BREWFILE
+
+          brew update-reset
+          # homebrew fails because `openssl` is a symlink while it tries to remove a directory.
+          rm /usr/local/Cellar/openssl || true
+          # homebrew fails to update python 3.9.1 to 3.9.1.1 due to unlinking failure
+          rm /usr/local/bin/2to3 || true
+
+          brew bundle
+      - name: Build GPG
+        # Workaround to correctly build pinentry on the latest GHA on
+        # macOS.  Most likely there is a better solution.
+        env:
+          CFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+          CXXFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+        run: |
+          bash -x "./examples/${SCRIPT}.sh" --no-ldconfig

--- a/.github/workflows/macos-11.0.yml
+++ b/.github/workflows/macos-11.0.yml
@@ -1,0 +1,72 @@
+name: macOS 11.0
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  tests:
+    runs-on: macos-11.0
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        env:
+          - SCRIPT: all_2.1
+          - SCRIPT: all_2.2
+          - SCRIPT: build_dir
+          - SCRIPT: components_individually
+          - SCRIPT: configure_options
+          - SCRIPT: gpgme
+          - SCRIPT: install_prefix
+          - SCRIPT: no_ldconfig
+          - SCRIPT: no_sudo
+          - SCRIPT: verify
+
+        exclude:
+          - env:
+              SCRIPT: all_2.1  # libksba too old for macOS
+          - env:
+              SCRIPT: no_sudo
+
+    env: ${{ matrix.env }}
+    timeout-minutes: 70
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up build environment
+        run: |
+          cat > Brewfile <<BREWFILE
+          brew "openssl@1.1"
+          brew "make"
+          brew "autoconf"
+          brew "automake"
+          brew "libtool"
+          brew "pkg-config"
+          brew "gnupg"
+          brew "bison"
+          BREWFILE
+
+          brew update-reset
+          # homebrew fails because `openssl` is a symlink while it tries to remove a directory.
+          rm /usr/local/Cellar/openssl || true
+          # homebrew fails to update python 3.9.1 to 3.9.1.1 due to unlinking failure
+          rm /usr/local/bin/2to3 || true
+
+          brew bundle
+      - name: Import GnuPG keys for "verify.sh" example
+        if: ${{ matrix.env.SCRIPT == 'verify' }}
+        run: |
+          bash ci/import_gpg_keys.sh
+      - name: Build GPG
+        # Workaround to correctly build pinentry on the latest GHA on
+        # macOS.  Most likely there is a better solution.
+        env:
+          CFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+          CXXFLAGS: "-D_XOPEN_SOURCE_EXTENDED"
+        run: |
+          bash -x "./examples/${SCRIPT}.sh" --no-ldconfig

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ A set of build scripts for GNU Privacy Guard.
 
 [options="header"]
 |==========================
-|distro       |        |latest  |head
+|OS \ GPG version |2.1, 2.2  |latest   |head
 
 |Fedora 33
 |image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/fedora-33.yml/badge.svg["Fedora 33", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/fedora-33.yml"]
@@ -40,6 +40,16 @@ A set of build scripts for GNU Privacy Guard.
 |image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/ubuntu-14.04.yml/badge.svg["Ubuntu 14.04", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/ubuntu-14.04.yml"]
 |image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/ubuntu-14.04-latest.yml/badge.svg["Ubuntu 14.04 (latest)", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/ubuntu-14.04-latest.yml"]
 |image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/ubuntu-14.04-head.yml/badge.svg["Ubuntu 14.04 (head)", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/ubuntu-14.04-head.yml"] footnote:[Version of gettext is too old in Ubuntu 14.04.]
+
+|macOS 11.0
+|image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-11.0.yml/badge.svg["macOS 11.0", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-11.0.yml"]
+|image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-11.0-latest.yml/badge.svg["macOS 11.0 (latest)", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-11.0-latest.yml"]
+|image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-11.0-head.yml/badge.svg["macOS 11.0 (head)", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-11.0-head.yml"]
+
+|macOS 10.15
+|image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-10.15.yml/badge.svg["macOS 10.15", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-10.15.yml"]
+|image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-10.15-latest.yml/badge.svg["macOS 10.15 (latest)", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-10.15-latest.yml"]
+|image:https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-10.15-head.yml/badge.svg["macOS 10.15 (head)", link="https://github.com/rnpgp/gpg-build-scripts/actions/workflows/macos-10.15-head.yml"]
 |==========================
 
 

--- a/examples/gpgme.sh
+++ b/examples/gpgme.sh
@@ -36,4 +36,5 @@ gpgme-config --version | head -n 1 | cut -d" " -f 3 | grep -xE "1\.[0-9]+\.[0-9]
 [[ $(gpgme-config --prefix) == "/usr/local" ]]
 
 # Assert the presence of dynamic library…
-[[ -f /usr/local/lib/libgpgme.so ]]
+# shellcheck disable=SC2010
+ls /usr/local/lib/libgpgme.{so,dylib} 2>/dev/null | grep -q .

--- a/examples/no_ldconfig.sh
+++ b/examples/no_ldconfig.sh
@@ -33,6 +33,12 @@ set -v # Print executed lines
 
 PREFIX="/opt/gnupg"
 
+# Put PREFIX under a temp dir if PREFIX is not writable.
+if	[[ ! -d "${PREFIX%/*}" && ! -w /              ]] || \
+	[[ ! -d "${PREFIX}"    && ! -w "${PREFIX%/*}" ]]; then
+	PREFIX="$(mktemp -d)${PREFIX}"
+fi
+
 GPG_CONFIGURE_OPTS="--prefix=${PREFIX} \
 	--with-libgpg-error-prefix=${PREFIX} \
 	--with-libassuan-prefix=${PREFIX} \

--- a/install_gpg_all.sh
+++ b/install_gpg_all.sh
@@ -175,7 +175,7 @@ install_suite()
 	case "${_arg_suite}" in
 		"2.2")
 			install_gpg_components  \
-				libgpg-error 1.32   \
+				libgpg-error 1.33   \
 				libgcrypt    1.8.6  \
 				libassuan    2.5.3  \
 				libksba      1.4.0  \


### PR DESCRIPTION
As of writing, `head` is failing for macos-10.15, and [GitHub Action pool for macos-11.0 has been unavailable for new users](https://github.com/actions/virtual-environments/issues/2486) so I'm unable to test against `macos-11.0` on my own fork.

Closes #32 